### PR TITLE
🔥 Remove Greenkeeper badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # 🔓 vue-password-strength-meter
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/apertureless/vue-password-strength-meter.svg)](https://greenkeeper.io/)
 [![Build Status](https://travis-ci.org/apertureless/vue-password-strength-meter.svg?branch=master)](https://travis-ci.org/apertureless/vue-password-strength-meter)
 [![npm version](https://badge.fury.io/js/vue-password-strength-meter.svg)](https://badge.fury.io/js/vue-password-strength-meter)
 [![vue2](https://img.shields.io/badge/vue-2.x-brightgreen.svg)](https://vuejs.org/)


### PR DESCRIPTION
Removed greenkeeper because of incompatibility with yarn & travis.

## Description

## Fix or Feature?

### Environment
- OS: Write here
- NPM Version: Write here

