### PR TITLE
Rename errorClass and successClass

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Interactive password strength meter based on [zxcvbn](https://github.com/dropbox
 | secureLength |  Number | 7 | password min length |
 | badge |  Boolean | true | display password count badge |
 | defaultClass |  String | Password__field | input field class |
-| errorClass |  String | has-error | error class for password count badge |
-| successClass |  String | is-success | success class for password count badge |
+| errorClass |  String | Password__badge--error | error class for password count badge |
+| successClass |  String | Password__badge--success | success class for password count badge |
 | strengthMeterClass |  String | Password__strength-meter | strength-meter class |
 | strengthMeterFillClass |  String | Password__strength-meter--fill | strength-meter class for individual data fills |
 

--- a/src/components/PasswordStrengthMeter.vue
+++ b/src/components/PasswordStrengthMeter.vue
@@ -109,7 +109,7 @@
        */
       errorClass: {
         type: String,
-        default: 'has-error'
+        default: 'Password__badge--error'
       },
       /**
        * CSS Class for the badge
@@ -120,7 +120,7 @@
        */
       successClass: {
         type: String,
-        default: 'is-success'
+        default: 'Password__badge--success'
       },
       /**
        * CSS class for styling the
@@ -299,11 +299,11 @@
     line-height: 1.1;
   }
 
-  .has-error {
+  .Password__badge--error {
     background: red;
   }
 
-  .is-success {
+  .Password__badge--success {
     background: #1bbf1b;
   }
 </style>


### PR DESCRIPTION
Renamed to a more specific class name so it does not produce errors with css frameworks.
Closes #8 