### PR TITLE
fix: prevent toggleButton from getting called on input enter

### DIFF
--- a/src/components/PasswordStrengthMeter.vue
+++ b/src/components/PasswordStrengthMeter.vue
@@ -26,6 +26,7 @@
           v-if="toggle"
           class="Password__toggle">
             <button
+              type="button"
               class="btn-clean"
               :aria-label="showPasswordLabel"
               @click.prevent="togglePassword()">


### PR DESCRIPTION
## Description
When this component is placed inside a `<form>` component, on pressing enter instead of submitting the form, it click on the `togglePassword` button. Adding `type="button"` fixes that issue.

## Fix or Feature?
Fix

### Environment
- OS: MacOS (But should work the same in all)
- NPM Version: 6.2.0

