### PR TITLE
Fix responsive behaviour breaks (#29)

### DIFF
--- a/src/components/PasswordStrengthMeter.vue
+++ b/src/components/PasswordStrengthMeter.vue
@@ -359,16 +359,16 @@
     border-style: solid;
     border-width: 0 5px 0 5px;
     position: absolute;
-    width: 80px;
+    width: 20%;
     z-index: 10;
   }
 
   .Password__strength-meter:before {
-    left: 70px;
+    left: 20%;
   }
 
   .Password__strength-meter:after {
-    right: 70px;
+    right: 20%;
   }
 
   .Password__strength-meter--fill {


### PR DESCRIPTION
## Description

Currently the password strength meter is not responsive due to fixed px sizes. This PR convert those pixel width to use percent.

## Fix or Feature?

Fix

### Environment
- OS: Windows
- NPM Version: 1.3.2

