### PR TITLE
Fix Vue warning

### DIFF
--- a/src/components/PasswordStrengthMeter.vue
+++ b/src/components/PasswordStrengthMeter.vue
@@ -256,7 +256,7 @@
        */
       userInputs: {
         type: Array,
-        default: []
+        default: () => []
       }
     },
     data () {


### PR DESCRIPTION
## Description
Fix Vue warning: Invalid default value for prop "userInputs": Props with type Object/Array must use a factory function to return the default value.

## Fix or Feature?
Fix

### Environment
- OS: Windows
- NPM Version: 6.9.0

