### PR TITLE
Fix the separator overflow issue by creating separator divs

### DIFF
--- a/src/components/PasswordStrengthMeter.vue
+++ b/src/components/PasswordStrengthMeter.vue
@@ -47,6 +47,10 @@
 
     <div v-if="showStrengthMeter" :class="[strengthMeterClass]">
       <div :class="[strengthMeterFillClass]" :data-score="passwordStrength"></div>
+      <div :class="[strengthMeterSeparatorClass]" :data-separator-index="'1'"></div>
+      <div :class="[strengthMeterSeparatorClass]" :data-separator-index="'2'"></div>
+      <div :class="[strengthMeterSeparatorClass]" :data-separator-index="'3'"></div>
+      <div :class="[strengthMeterSeparatorClass]" :data-separator-index="'4'"></div>
     </div>
   </div>
 </template>
@@ -188,6 +192,15 @@
         default: 'Password__strength-meter--fill'
       },
       /**
+       * CSS class for styling the
+       * strength meter separators.
+       * @type {String}
+       */
+      strengthMeterSeparatorClass: {
+        type: String,
+        default: 'Password__strength-meter--separator'
+      },
+      /**
        * Label for the show password icon
        */
       labelShow: {
@@ -308,33 +321,38 @@
     position: relative;
   }
 
+  $strengthMeterHeight : 3px;
+
   .Password__strength-meter {
     position: relative;
-    height: 3px;
+    height: $strengthMeterHeight;
     background: #DDD;
     margin: 10px auto 20px;
     border-radius: 3px;
 }
 
-  .Password__strength-meter:before, .Password__strength-meter:after {
-    content: '';
-    height: inherit;
-    background: transparent;
-    display: block;
-    border-color: #FFF;
-    border-style: solid;
-    border-width: 0 5px 0 5px;
+  .Password__strength-meter--separator {
+    background-color: #FFF;
+    width: 5px;
+    height: $strengthMeterHeight;
+    display: inline-block;
     position: absolute;
-    width: 20%;
-    z-index: 10;
   }
 
-  .Password__strength-meter:before {
+  .Password__strength-meter--separator[data-separator-index='1'] {
     left: 20%;
   }
 
-  .Password__strength-meter:after {
-    right: 20%;
+  .Password__strength-meter--separator[data-separator-index='2'] {
+    left: 40%;
+  }
+
+  .Password__strength-meter--separator[data-separator-index='3'] {
+    left: 60%;
+  }
+
+  .Password__strength-meter--separator[data-separator-index='4'] {
+    left: 80%;
   }
 
   .Password__strength-meter--fill {


### PR DESCRIPTION
Got the idea from : https://github.com/MorrisJobke/strengthify

## Description

The coloured meter bar would underfill, or overflow.

This fix also makes the meter bars even in size.

Before

![image](https://user-images.githubusercontent.com/890368/104091484-5334da00-5286-11eb-8715-519d407c90f0.png)

![image](https://user-images.githubusercontent.com/890368/104091680-7a3fdb80-5287-11eb-8805-73814fff9e62.png)

After

![image](https://user-images.githubusercontent.com/890368/104091489-5fb93280-5286-11eb-804d-1ba3672a8e22.png)

![image](https://user-images.githubusercontent.com/890368/104091686-8461da00-5287-11eb-84d9-1c3d32e37b65.png)

## Fix or Feature?

This is a fix.

### Environment
- OS: Windows 10
- NPM Version: 6.14.9

